### PR TITLE
Allow setting ssl/unencrypted plaintext when using Mtik:command()

### DIFF
--- a/bin/tikcommand
+++ b/bin/tikcommand
@@ -66,6 +66,8 @@ p MTik::command(
   :host=>ARGV[0],
   :user=>ARGV[1],
   :pass=>ARGV[2],
-  :command=>command
-)
+  :ssl => ENV['MTIK_SSL'] || false,
+  :command=>command,
 
+  :unencrypted_plaintext => ENV['MTIK_UNENCRYPTED_PLAINTEXT'] || false,
+)

--- a/lib/mtik.rb
+++ b/lib/mtik.rb
@@ -207,6 +207,8 @@ module MTik
   ##     :pass    => the API password to authenticate with
   ##     :command => one or more API commands to execute
   ##     :limit   => an OPTIONAL integer reply limit
+  ##     :use_ssl => use SSL for connecting to mikrotik device
+  ##     :unencrypted_plaintext => use 6.43+ login even without ssl
   ##
   ## The :command parameter may be:
   ##   * A single string representing a single API command to execute
@@ -250,8 +252,11 @@ module MTik
       :user => args[:user],
       :pass => args[:pass],
       :port => args[:port],
+      :ssl  => args[:ssl],
+
       :conn_timeout => args[:conn_timeout],
-      :cmd_timeout  => args[:cmd_timeout]
+      :cmd_timeout  => args[:cmd_timeout],
+      :unencrypted_plaintext => args[:unencrypted_plaintext],
     )
     limit = args[:limit]  ## Optional reply limit
     cmd = args[:command]

--- a/lib/mtik/connection.rb
+++ b/lib/mtik/connection.rb
@@ -62,7 +62,7 @@ class MTik::Connection
     @ssl_sock              = nil
     @requests              = Hash.new
     @use_ssl               = args[:ssl] || MTik::USE_SSL
-    @unencrypted_plaintext = args[:unecrypted_plaintext]
+    @unencrypted_plaintext = args[:unencrypted_plaintext]
     @host                  = args[:host]
     @port                  = args[:port] || (@use_ssl ? MTik::PORT_SSL : MTik::PORT)
     @user                  = args[:user] || MTik::USER


### PR DESCRIPTION
The Mtik::Connection allows setting :ssl and :unencrypted_plaintext arguments to for use of new login type. But these are not used by Mtik:command() and connection to newer Mikrotik devices fails on login (on Mikrotik 6.45.3).

The pull-request fixes one typo and allows passing above mentioned args from Mtik::command() to Mtik::Connection.

